### PR TITLE
✨ feat(server): Add Vulkan and Xwayland support

### DIFF
--- a/.dev/x11.sh
+++ b/.dev/x11.sh
@@ -1,0 +1,13 @@
+#This fixes the error where x11-apps in docker cannot seem to access the hosts DISPLAY server
+    # Error: No protocol specified
+    # Error: Can't open display: :10.0
+#https://askubuntu.com/a/1470341 //Run it on host OS
+xhost +Local:*
+xhost 
+
+#Fun fact Weston won't run if you do not have Wayland running on the host (i have yet to try running with Xwayland inside the container)
+#Run weston using your host's X11 display server
+weston --backend=x11-backend.so
+
+#Run inside the terminal of the weston you just created... cool right?
+weston --backend=wayland-backend.so

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -29,10 +29,10 @@ ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
 
-COPY .scripts/ /usr/bin/netris/
+# COPY .scripts/ /usr/bin/netris/
 
-RUN ls -la /usr/bin/netris \
-    && chmod +x /usr/bin/netris/proton
+# RUN ls -la /usr/bin/netris \
+#     && chmod +x /usr/bin/netris/proton
 
 # Expose NVIDIA libraries and paths
 ENV PATH=/usr/local/nvidia/bin:${PATH} \
@@ -43,6 +43,66 @@ ENV PATH=/usr/local/nvidia/bin:${PATH} \
     NVIDIA_DRIVER_CAPABILITIES=all \
     # Disable VSYNC for NVIDIA GPUs
     __GL_SYNC_TO_VBLANK=0
+
+ENV XDG_RUNTIME_DIR=/run/user/1000/ \ 
+    # DISPLAY=:0 \
+    WAYLAND_DISPLAY=wayland-0 \
+    PUID=0 \
+    PGID=0 \
+    UNAME="root"
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+    libwayland-server0 \
+    libwayland-client0 \
+    xwayland \ 
+    xdg-user-dirs \
+    xdg-utils \
+    #Vulkan
+    mesa-vulkan-drivers \
+    mesa-vulkan-drivers:i386 \
+    libvulkan-dev \
+    libvulkan-dev:i386 \
+    vulkan-tools \
+    # Install OpenGL libraries
+    libglvnd0 \
+    libglvnd0:i386 \
+    libgl1 \
+    libgl1:i386 \
+    libglx0 \
+    libglx0:i386 \
+    libegl1 \
+    libegl1:i386 \
+    libgles2 \
+    libgles2:i386 \
+    libglu1 \
+    libglu1:i386 \
+    libsm6 \
+    libsm6:i386 \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
+    && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf \
+    # Configure Vulkan manually
+    && VULKAN_API_VERSION=$(dpkg -s libvulkan1 | grep -oP 'Version: [0-9|\.]+' | grep -oP '[0-9]+(\.[0-9]+)(\.[0-9]+)') \
+    && mkdir -pm755 /etc/vulkan/icd.d/ \
+    && echo "{\n\
+        \"file_format_version\" : \"1.0.0\",\n\
+        \"ICD\": {\n\
+            \"library_path\": \"libGLX_nvidia.so.0\",\n\
+            \"api_version\" : \"${VULKAN_API_VERSION}\"\n\
+        }\n\
+    }" > /etc/vulkan/icd.d/nvidia_icd.json \
+    # Configure EGL manually
+    && mkdir -pm755 /usr/share/glvnd/egl_vendor.d/ \
+    && echo "{\n\
+        \"file_format_version\" : \"1.0.0\",\n\
+        \"ICD\": {\n\
+            \"library_path\": \"libEGL_nvidia.so.0\"\n\
+        }\n\
+    }" > /usr/share/glvnd/egl_vendor.d/10_nvidia.json \
+    # Prepare the XDG_RUNTIME_DIR for wayland
+    && mkdir -p ${XDG_RUNTIME_DIR} && chmod 0700 ${XDG_RUNTIME_DIR}
+
 
 #Install proton
 # RUN /usr/bin/netris/proton -i

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:20.04 as runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+   apt install -y x11-apps
+
+CMD /usr/bin/xclock

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,8 +1,0 @@
-FROM ubuntu:20.04 as runtime
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt update && \
-   apt install -y x11-apps
-
-CMD /usr/bin/xclock


### PR DESCRIPTION
## Description

**What(what issue does this code solve/what feature does it add):**

We have no display server inside the container, nor Vulkan which will later be required by dxvk/d3d11/d3d12 in order to play games using Proton.

**How(how does it solve it):**

1. We added vulkan and Xwayland packages into `server.Dockerfile` , then tested with running `vkcube` and `vulkaninfo` after running an interactive bash shell inside the container.

## Required Checklist:

- [ ] I have added any necessary documentation  and comments in my code (where appropriate)
- [ ] I have added tests to make sure my code runs in all contexts

## Further comments