### PR TITLE
✨ feat(server): Integrate gpu-screen-recorder into the server

### DIFF
--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -131,6 +131,4 @@ ENTRYPOINT ["/tini", "--"]
 COPY --from=recorder /usr/bin/gpu-screen-recorder /usr/bin/gpu-screen-recorder 
 COPY --from=recorder /usr/bin/gsr-kms-server /usr/bin/gsr-kms-server
 
-RUN /usr/bin/gpu-screen-recorder --help
-
 CMD [ "/usr/bin/netris/entrypoint.sh" ]

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,7 @@
 #This contains all the necessary libs for the server to work.
 #NOTE: KEEP THIS IMAGE AS LEAN AS POSSIBLE.
+FROM ghcr.io/wanjohiryan/netris/recorder:nightly as recorder
+
 FROM ubuntu:23.10
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -125,5 +127,10 @@ ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
+
+COPY --from=recorder /usr/bin/gpu-screen-recorder /usr/bin/gpu-screen-recorder 
+COPY --from=recorder /usr/bin/gsr-kms-server /usr/bin/gsr-kms-server
+
+RUN /usr/bin/gpu-screen-recorder --help
 
 CMD [ "/usr/bin/netris/entrypoint.sh" ]


### PR DESCRIPTION
## Description

**What(what issue does this code solve/what feature does it add):**

We succesfully built the gpu-screen-recorder in a separate container... now we need to add it into the main container

**How(how does it solve it):**
1. Copy the relevant user/bin files from the separate docker image
2. 
## Required Checklist:

- [x] I have added any necessary documentation  and comments in my code (where appropriate)
- [ ] I have added tests to make sure my code runs in all contexts

## Further comments