### PR TITLE
🐛 fix(server): Clean up the supervisord.conf and COPY supervisord.conf to /etc

### DIFF
--- a/.scripts/supervisord.conf
+++ b/.scripts/supervisord.conf
@@ -6,7 +6,7 @@ logfile=/tmp/supervisord.log
 pidfile=/tmp/supervisord.pid
 
 [program:entrypoint]
-command=/usr/bin/netris/entrypoint.sh
+command=/etc/entrypoint.sh
 logfile=/tmp/entrypoint.log
 pidfile=/tmp/entrypoint.pid
 stopsignal=INT

--- a/.scripts/supervisord.conf
+++ b/.scripts/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
-user=netris
+user=ubuntu
 nodaemon=true
 loglevel=info
 logfile=/tmp/supervisord.log
@@ -16,7 +16,7 @@ redirect_stderr=true
 priority=1
 
 [program:pulseaudio]
-user=netris
+user=ubuntu
 command=bash -c "until [ -S \"/tmp/.X11-unix/X${DISPLAY/:/}\" ]; do sleep 1; done; sudo /usr/bin/pulseaudio -k >/dev/null 2>&1 || sudo /usr/bin/pulseaudio --system --verbose --log-target=stderr --realtime=true --disallow-exit -L 'module-native-protocol-tcp auth-ip-acl=127.0.0.0/8 port=4713 auth-anonymous=1'"
 environment=DISPLAY=":0"
 logfile=/tmp/pulseaudio.log

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 COPY warp /usr/bin/netris/
 RUN chmod +x /usr/bin/netris/warp
-COPY .scripts/entrypoint.sh .scripts/supervisord.conf /etc/netris/
+COPY .scripts/entrypoint.sh .scripts/supervisord.conf /etc/
 RUN chmod 755 /etc/supervisord.conf /etc/entrypoint.sh
 
 USER 1000


### PR DESCRIPTION
## Description

**What(what issue does this code solve/what feature does it add):**
Docker build server fails because `supervisord.conf` is getting copied to a different directory other than `/etc`
**How(how does it solve it):**

## Required Checklist:

- [ ] I have added any necessary documentation  and comments in my code (where appropriate)
- [ ] I have added tests to make sure my code runs in all contexts

## Further comments