### PR TITLE
🐛 fix(server): Run input-server as root to get permissions to create …

### DIFF
--- a/.scripts/entrypoint.sh
+++ b/.scripts/entrypoint.sh
@@ -161,7 +161,7 @@ fi
 openbox-session &
 
 #Now we can safely run our input server without permission errors
-/inputtino/input-server &
+sudo /inputtino/input-server &
 
 /usr/games/gamescope -- mangohud glxgears > /dev/null &
 


### PR DESCRIPTION
…devices

## Description

**What(what issue does this code solve/what feature does it add):**
Currently we get a permission error when trying to create a mouse.

On further investigation, we realise that we have to run `/inputtino/input-server` as sudo/root.

**How(how does it solve it):**

## Required Checklist:

- [ ] I have added any necessary documentation  and comments in my code (where appropriate)
- [ ] I have added tests to make sure my code runs in all contexts

## Further comments