### PR TITLE
🐛 fix(github): Add build type to auto-labeller for dependabot

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,3 @@
 ## Description
 
-**What(what issue does this code solve/what feature does it add):**
-
-**How(how does it solve it):**
-
-## Required Checklist:
-
-- [ ] I have added any necessary documentation  and comments in my code (where appropriate)
-- [ ] I have added tests to make sure my code runs in all contexts
-
-## Further comments
+**What issue are you solving (or what feature are you adding) and how are you doing it?**

--- a/.github/workflows/autolabeller.yml
+++ b/.github/workflows/autolabeller.yml
@@ -26,22 +26,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_MASTER_TOKEN }}
         with:
-            #TODO: fix all emojis
           types: |-
+            build
+            chore
+            ci
+            deprecate
+            docs
             feat
             fix
-            chore
-            docs
-            test
-            security
+            perf
+            refactor
             remove
             revert
-            perf
+            security
             style
-            deprecate
-            refactor
-            ci
-            build
+            test
           requireScope: false
           # Ensures the subject start with an uppercase character.
           subjectPattern: ^([A-Z]).+$


### PR DESCRIPTION
## Description

**What(what issue does this code solve/what feature does it add):**

Dependabot does not have a `build` semver type and it keeps triggering the autolabeller. So, i added that in there, plus slimmed down the pull_request_template as it required too much info, which made it too cumbersome filling it